### PR TITLE
Test Owner Information Page: Verify details and visits using mock data

### DIFF
--- a/test-data/pet.json
+++ b/test-data/pet.json
@@ -1,38 +1,38 @@
 [
   {
-    "firstName": "Kylian",
-    "lastName": "Mbappe",
-    "address": "la liga",
-    "city": "madrid",
-    "telephone": "0000000001",
+    "firstName": "John",
+    "lastName": "Walker",
+    "address": "12 Oak Street",
+    "city": "Springfield",
+    "telephone": "1234567890",
     "id": 1001,
     "pets": [
       {
         "id": 3010,
-        "name": "Shadow",
-        "birthDate": "2010-11-17",
+        "name": "Max",
+        "birthDate": "2015-04-10",
         "type": {
           "name": "dog",
           "id": 2000
         },
         "ownerId": 1001,
         "visits": [
-          { "date": "2025-05-01", "description": "checkup 1", "id": 1, "petId": null },
-          { "date": "2025-05-02", "description": "checkup 2", "id": 2, "petId": null },
-          { "date": "2025-05-03", "description": "checkup 3", "id": 3, "petId": null },
-          { "date": "2025-05-04", "description": "checkup 4", "id": 4, "petId": null },
-          { "date": "2025-05-05", "description": "checkup 5", "id": 5, "petId": null },
-          { "date": "2025-05-06", "description": "checkup 6", "id": 6, "petId": null },
-          { "date": "2025-05-07", "description": "checkup 7", "id": 7, "petId": null },
-          { "date": "2025-05-08", "description": "checkup 8", "id": 8, "petId": null },
-          { "date": "2025-05-09", "description": "checkup 9", "id": 9, "petId": null },
-          { "date": "2025-05-10", "description": "checkup 10", "id": 10, "petId": null }
+          { "date": "2025-05-01", "description": "Annual vaccination", "id": 1, "petId": null },
+          { "date": "2025-05-02", "description": "Dental cleaning", "id": 2, "petId": null },
+          { "date": "2025-05-03", "description": "Skin check", "id": 3, "petId": null },
+          { "date": "2025-05-04", "description": "Ear infection treatment", "id": 4, "petId": null },
+          { "date": "2025-05-05", "description": "Flea and tick prevention", "id": 5, "petId": null },
+          { "date": "2025-05-06", "description": "Routine check-up", "id": 6, "petId": null },
+          { "date": "2025-05-07", "description": "Stomach issue", "id": 7, "petId": null },
+          { "date": "2025-05-08", "description": "Limping on left leg", "id": 8, "petId": null },
+          { "date": "2025-05-09", "description": "Eye irritation", "id": 9, "petId": null },
+          { "date": "2025-05-10", "description": "Booster shots", "id": 10, "petId": null }
         ]
       },
       {
         "id": 3011,
-        "name": "Bolt",
-        "birthDate": "2011-06-06",
+        "name": "Bella",
+        "birthDate": "2018-09-22",
         "type": {
           "name": "dog",
           "id": 2001
@@ -43,17 +43,17 @@
     ]
   },
   {
-    "firstName": "Betty",
-    "lastName": "Davis",
-    "address": "638 Cardinal Ave.",
-    "city": "Sun Prairie",
-    "telephone": "6085551749",
+    "firstName": "Emily",
+    "lastName": "Stone",
+    "address": "45 Maple Avenue",
+    "city": "Riverdale",
+    "telephone": "9876543210",
     "id": 1035,
     "pets": [
       {
         "id": 2043,
-        "name": "Basil",
-        "birthDate": "2002-08-06",
+        "name": "Milo",
+        "birthDate": "2020-08-06",
         "type": {
           "name": "hamster",
           "id": 1749
@@ -63,8 +63,8 @@
       },
       {
         "id": 2044,
-        "name": "Fluffy",
-        "birthDate": "2011-03-20",
+        "name": "Luna",
+        "birthDate": "2017-03-20",
         "type": {
           "name": "cat",
           "id": 1750
@@ -74,8 +74,8 @@
       },
       {
         "id": 2045,
-        "name": "Tiger",
-        "birthDate": "2012-07-11",
+        "name": "Rocky",
+        "birthDate": "2016-07-11",
         "type": {
           "name": "dog",
           "id": 1751
@@ -85,8 +85,8 @@
       },
       {
         "id": 2046,
-        "name": "Chirpy",
-        "birthDate": "2014-01-30",
+        "name": "Tweety",
+        "birthDate": "2019-01-30",
         "type": {
           "name": "bird",
           "id": 1752
@@ -96,8 +96,8 @@
       },
       {
         "id": 2047,
-        "name": "Nemo",
-        "birthDate": "2015-05-05",
+        "name": "Goldie",
+        "birthDate": "2021-05-05",
         "type": {
           "name": "fish",
           "id": 1753

--- a/tests/api-tests/petClinic.spec.ts
+++ b/tests/api-tests/petClinic.spec.ts
@@ -23,7 +23,7 @@ test('Mocked owners list and detail validation', async ({ page }) => {
   const rowsOfOwners = page.locator('table > tbody > tr')
   await expect(rowsOfOwners).toHaveCount(2)
 
-  const firstOwnerRow = page.getByRole('row', { name: 'Kylian Mbappe' })
+  const firstOwnerRow = page.getByRole('row', { name: 'John Walker' })
   await expect(firstOwnerRow.locator('td').nth(4).locator('tr')).toHaveCount(2)
   const name = await firstOwnerRow.locator('td a').textContent()
   const address = await firstOwnerRow.locator('td').nth(1).textContent()
@@ -32,15 +32,15 @@ test('Mocked owners list and detail validation', async ({ page }) => {
   const firstOwnerInfoFromList = { name, address, city, telephone }
   const firstOwnerPets = (await firstOwnerRow.locator('td').nth(4).locator('tr').allTextContents())
     .map(pet => pet.trim())
-  expect(firstOwnerPets).toEqual(['Shadow', 'Bolt'])
+  expect(firstOwnerPets).toEqual(['Max', 'Bella'])
 
-  const secondOwnerRow = page.getByRole('row', { name: 'Betty Davis' })
+  const secondOwnerRow = page.getByRole('row', { name: 'Emily Stone' })
   await expect(secondOwnerRow.locator('td').nth(4).locator('tr')).toHaveCount(5)
   const secondOwnerPets = (await secondOwnerRow.locator('td').nth(4).locator('tr').allTextContents())
     .map(pet => pet.trim())
-  expect(secondOwnerPets).toEqual(['Basil', 'Fluffy', 'Tiger', 'Chirpy', 'Nemo'])
+  expect(secondOwnerPets).toEqual(['Milo', 'Luna', 'Rocky', 'Tweety', 'Goldie'])
 
-  await page.getByRole('link', { name: 'Kylian Mbappe' }).click()
+  await page.getByRole('link', { name: 'John Walker' }).click()
 
   const firstOwnerInformationTable = page.locator('table').first()
   const detailName = await firstOwnerInformationTable.locator('tr').nth(0).locator('td b').textContent()


### PR DESCRIPTION
	1.	For steps 5 and 6:
Since the test case says “names should match the names from the Owners page” and “Owner details should match the information from the Owners page”,
I interpreted this as a requirement to compare dynamically between the list page and the details page.
Since the test required matching data between the Owners list and the Owner Information page,
I first collected pet names and owner info as variables from the list page,
and then asserted against those values on the details page.
I’m not sure that this approach may seem like an extra or unnecessary step at first glance,
but I chose it intentionally to follow the test case wording closely

     2.	For steps 7 and 8:
Both seem to ask for validating that the pet has 10 visits displayed.
I used a single toHaveCount(10) assertion for this — let me know if you expect separate checks.